### PR TITLE
push ops to track changes when document is flushed

### DIFF
--- a/app/coffee/DocumentManager.coffee
+++ b/app/coffee/DocumentManager.coffee
@@ -4,6 +4,7 @@ DocOpsManager = require "./DocOpsManager"
 DiffCodec = require "./DiffCodec"
 logger = require "logger-sharelatex"
 Metrics = require "./Metrics"
+TrackChangesManager = require "./TrackChangesManager"
 
 module.exports = DocumentManager =
 	getDoc: (project_id, doc_id, _callback = (error, lines, version) ->) ->
@@ -90,7 +91,9 @@ module.exports = DocumentManager =
 				logger.log project_id: project_id, doc_id: doc_id, version: version, "flushing doc"
 				PersistenceManager.setDoc project_id, doc_id, lines, version, (error) ->
 					return callback(error) if error?
-					callback null
+					TrackChangesManager.flushDocChanges project_id, doc_id,  (error) ->
+						return callback(error) if error?
+						callback null
 
 	flushAndDeleteDoc: (project_id, doc_id, _callback = (error) ->) ->
 		timer = new Metrics.Timer("docManager.flushAndDeleteDoc")

--- a/test/unit/coffee/DocumentManager/flushAndDeleteDocTests.coffee
+++ b/test/unit/coffee/DocumentManager/flushAndDeleteDocTests.coffee
@@ -8,6 +8,7 @@ describe "DocumentUpdater - flushAndDeleteDoc", ->
 	beforeEach ->
 		@DocumentManager = SandboxedModule.require modulePath, requires:
 			"./RedisManager": @RedisManager = {}
+			"./TrackChangesManager": @TrackChangesManager = {}
 			"./PersistenceManager": @PersistenceManager = {}
 			"logger-sharelatex": @logger = {log: sinon.stub()}
 			"./DocOpsManager" :{}

--- a/test/unit/coffee/DocumentManager/flushDocTests.coffee
+++ b/test/unit/coffee/DocumentManager/flushDocTests.coffee
@@ -8,6 +8,7 @@ describe "DocumentUpdater - flushDocIfLoaded", ->
 	beforeEach ->
 		@DocumentManager = SandboxedModule.require modulePath, requires:
 			"./RedisManager": @RedisManager = {}
+			"./TrackChangesManager": @TrackChangesManager = {}
 			"./PersistenceManager": @PersistenceManager = {}
 			"./DocOpsManager": @DocOpsManager = {}
 			"logger-sharelatex": @logger = {log: sinon.stub()}
@@ -23,6 +24,7 @@ describe "DocumentUpdater - flushDocIfLoaded", ->
 	describe "when the doc is in Redis", ->
 		beforeEach ->
 			@RedisManager.getDoc = sinon.stub().callsArgWith(1, null, @lines, @version)
+			@TrackChangesManager.flushDocChanges = sinon.stub().callsArg(2)
 			@PersistenceManager.setDoc = sinon.stub().callsArgWith(4)
 			@DocumentManager.flushDocIfLoaded @project_id, @doc_id, @callback
 

--- a/test/unit/coffee/DocumentManager/getDocAndRecentOpsTests.coffee
+++ b/test/unit/coffee/DocumentManager/getDocAndRecentOpsTests.coffee
@@ -8,6 +8,7 @@ describe "DocumentUpdater - getDocAndRecentOps", ->
 	beforeEach ->
 		@DocumentManager = SandboxedModule.require modulePath, requires:
 			"./RedisManager": @RedisManager = {}
+			"./TrackChangesManager": @TrackChangesManager = {}
 			"./PersistenceManager": @PersistenceManager = {}
 			"./DocOpsManager": @DocOpsManager = {}
 			"logger-sharelatex": @logger = {log: sinon.stub()}

--- a/test/unit/coffee/DocumentManager/getDocTests.coffee
+++ b/test/unit/coffee/DocumentManager/getDocTests.coffee
@@ -8,6 +8,7 @@ describe "DocumentUpdater - getDoc", ->
 	beforeEach ->
 		@DocumentManager = SandboxedModule.require modulePath, requires:
 			"./RedisManager": @RedisManager = {}
+			"./TrackChangesManager": @TrackChangesManager = {}
 			"./PersistenceManager": @PersistenceManager = {}
 			"./DocOpsManager": @DocOpsManager = {}
 			"logger-sharelatex": @logger = {log: sinon.stub()}

--- a/test/unit/coffee/DocumentManager/setDocTests.coffee
+++ b/test/unit/coffee/DocumentManager/setDocTests.coffee
@@ -8,6 +8,7 @@ describe "DocumentManager - setDoc", ->
 	beforeEach ->
 		@DocumentManager = SandboxedModule.require modulePath, requires:
 			"./RedisManager": @RedisManager = {}
+			"./TrackChangesManager": @TrackChangesManager = {}
 			"./PersistenceManager": @PersistenceManager = {}
 			"./DiffCodec": @DiffCodec = {}
 			"./DocOpsManager":{}


### PR DESCRIPTION
Any time a document is flushed we push ops into track changes, so they are written to mongo.

Done after the document has been written, to preserve the write ordering of the current code - the track changes flushes happen after document writes.

This does expose us to failures on document flush if track changes is down for some reason, which we didn't have before.  The alternative would be to put it in flushAndDeleteDoc just before the document is removed from memory, because that happens less often.