### PR TITLE
don't log errors from redis backend

### DIFF
--- a/app/coffee/RedisBackend.coffee
+++ b/app/coffee/RedisBackend.coffee
@@ -100,7 +100,8 @@ class MultiClient
 					cb(error, result)
 		async.parallel jobs, (error, results) ->
 			if error?
-				logger.error {err: error}, "error in redis backend"
+				# suppress logging of errors
+				# logger.error {err: error}, "error in redis backend"
 			else
 				compareResults(results, "exec")
 			callback(primaryError, primaryResult)


### PR DESCRIPTION
this also picks up errors from RedisManager like "doc ops range is not loaded in redis"