### PR TITLE
log op versions pushed to track changes

### DIFF
--- a/app/coffee/WebRedisManager.coffee
+++ b/app/coffee/WebRedisManager.coffee
@@ -1,6 +1,7 @@
 Settings = require('settings-sharelatex')
 rclient = require("redis-sharelatex").createClient(Settings.redis.web)
 async = require "async"
+logger = require('logger-sharelatex')
 
 module.exports = WebRedisManager =
 	getPendingUpdatesForDoc : (doc_id, callback)->
@@ -25,6 +26,8 @@ module.exports = WebRedisManager =
 	pushUncompressedHistoryOps: (project_id, doc_id, ops = [], callback = (error, length) ->) ->
 		if ops.length == 0
 			return callback(new Error("cannot push no ops")) # This should never be called with no ops, but protect against a redis error if we sent an empty array to rpush
+		opVersions = ops.map (op) -> op?.v
+		logger.log project_id: project_id, doc_id: doc_id, op_versions: opVersions, "pushing uncompressed history ops"
 		jsonOps = ops.map (op) -> JSON.stringify op
 		async.parallel [
 			(cb) -> rclient.rpush "UncompressedHistoryOps:#{doc_id}", jsonOps..., cb


### PR DESCRIPTION
log the op versions when they are pushed to redis