### PR TITLE
add error check on unlock

### DIFF
--- a/app/coffee/LockManager.coffee
+++ b/app/coffee/LockManager.coffee
@@ -41,7 +41,7 @@ module.exports = LockManager =
 				logger.log {doc_id}, "doc is locked"
 				callback err, false
 
-	getLock: (doc_id, callback = (error) ->) ->
+	getLock: (doc_id, callback = (error, lockValue) ->) ->
 		startTime = Date.now()
 		do attempt = () ->
 			if Date.now() - startTime > LockManager.MAX_LOCK_WAIT_TIME


### PR DESCRIPTION
we don't log when an unlock finds that the lock has expired or been taken by another request
we could also error in that case - not sure of the implications of that though