### PR TITLE
change acceptance test to use redis history client

### DIFF
--- a/test/acceptance/coffee/ApplyingUpdatesToADocTests.coffee
+++ b/test/acceptance/coffee/ApplyingUpdatesToADocTests.coffee
@@ -4,7 +4,7 @@ chai.should()
 expect = chai.expect
 async = require "async"
 Settings = require('settings-sharelatex')
-rclient_web = require("redis-sharelatex").createClient(Settings.redis.web)
+rclient_history = require("redis-sharelatex").createClient(Settings.redis.history)
 rclient_du = require("redis-sharelatex").createClient(Settings.redis.documentupdater)
 Keys = Settings.redis.documentupdater.key_schema
 
@@ -49,10 +49,10 @@ describe "Applying updates to a doc", ->
 				done()
 
 		it "should push the applied updates to the track changes api", (done) ->
-			rclient_web.lrange "UncompressedHistoryOps:#{@doc_id}", 0, -1, (error, updates) =>
+			rclient_history.lrange "UncompressedHistoryOps:#{@doc_id}", 0, -1, (error, updates) =>
 				throw error if error?
 				JSON.parse(updates[0]).op.should.deep.equal @update.op
-				rclient_web.sismember "DocsWithHistoryOps:#{@project_id}", @doc_id, (error, result) =>
+				rclient_history.sismember "DocsWithHistoryOps:#{@project_id}", @doc_id, (error, result) =>
 					throw error if error?
 					result.should.equal 1
 					done()
@@ -82,9 +82,9 @@ describe "Applying updates to a doc", ->
 				done()
 
 		it "should push the applied updates to the track changes api", (done) ->
-			rclient_web.lrange "UncompressedHistoryOps:#{@doc_id}", 0, -1, (error, updates) =>
+			rclient_history.lrange "UncompressedHistoryOps:#{@doc_id}", 0, -1, (error, updates) =>
 				JSON.parse(updates[0]).op.should.deep.equal @update.op
-				rclient_web.sismember "DocsWithHistoryOps:#{@project_id}", @doc_id, (error, result) =>
+				rclient_history.sismember "DocsWithHistoryOps:#{@project_id}", @doc_id, (error, result) =>
 					result.should.equal 1
 					done()
 
@@ -127,12 +127,12 @@ describe "Applying updates to a doc", ->
 						done()
 
 			it "should push the applied updates to the track changes api", (done) ->
-				rclient_web.lrange "UncompressedHistoryOps:#{@doc_id}", 0, -1, (error, updates) =>
+				rclient_history.lrange "UncompressedHistoryOps:#{@doc_id}", 0, -1, (error, updates) =>
 					updates = (JSON.parse(u) for u in updates)
 					for appliedUpdate, i in @updates
 						appliedUpdate.op.should.deep.equal updates[i].op
 
-					rclient_web.sismember "DocsWithHistoryOps:#{@project_id}", @doc_id, (error, result) =>
+					rclient_history.sismember "DocsWithHistoryOps:#{@project_id}", @doc_id, (error, result) =>
 						result.should.equal 1
 						done()
 			

--- a/test/acceptance/coffee/ApplyingUpdatesToADocTests.coffee
+++ b/test/acceptance/coffee/ApplyingUpdatesToADocTests.coffee
@@ -7,6 +7,7 @@ Settings = require('settings-sharelatex')
 rclient_history = require("redis-sharelatex").createClient(Settings.redis.history)
 rclient_du = require("redis-sharelatex").createClient(Settings.redis.documentupdater)
 Keys = Settings.redis.documentupdater.key_schema
+HistoryKeys = Settings.redis.history.key_schema
 
 MockTrackChangesApi = require "./helpers/MockTrackChangesApi"
 MockWebApi = require "./helpers/MockWebApi"
@@ -49,10 +50,10 @@ describe "Applying updates to a doc", ->
 				done()
 
 		it "should push the applied updates to the track changes api", (done) ->
-			rclient_history.lrange "UncompressedHistoryOps:#{@doc_id}", 0, -1, (error, updates) =>
+			rclient_history.lrange HistoryKeys.uncompressedHistoryOps({@doc_id}), 0, -1, (error, updates) =>
 				throw error if error?
 				JSON.parse(updates[0]).op.should.deep.equal @update.op
-				rclient_history.sismember "DocsWithHistoryOps:#{@project_id}", @doc_id, (error, result) =>
+				rclient_history.sismember HistoryKeys.docsWithHistoryOps({@project_id}), @doc_id, (error, result) =>
 					throw error if error?
 					result.should.equal 1
 					done()
@@ -82,9 +83,9 @@ describe "Applying updates to a doc", ->
 				done()
 
 		it "should push the applied updates to the track changes api", (done) ->
-			rclient_history.lrange "UncompressedHistoryOps:#{@doc_id}", 0, -1, (error, updates) =>
+			rclient_history.lrange HistoryKeys.uncompressedHistoryOps({@doc_id}), 0, -1, (error, updates) =>
 				JSON.parse(updates[0]).op.should.deep.equal @update.op
-				rclient_history.sismember "DocsWithHistoryOps:#{@project_id}", @doc_id, (error, result) =>
+				rclient_history.sismember HistoryKeys.docsWithHistoryOps({@project_id}), @doc_id, (error, result) =>
 					result.should.equal 1
 					done()
 
@@ -127,12 +128,12 @@ describe "Applying updates to a doc", ->
 						done()
 
 			it "should push the applied updates to the track changes api", (done) ->
-				rclient_history.lrange "UncompressedHistoryOps:#{@doc_id}", 0, -1, (error, updates) =>
+				rclient_history.lrange HistoryKeys.uncompressedHistoryOps({@doc_id}), 0, -1, (error, updates) =>
 					updates = (JSON.parse(u) for u in updates)
 					for appliedUpdate, i in @updates
 						appliedUpdate.op.should.deep.equal updates[i].op
 
-					rclient_history.sismember "DocsWithHistoryOps:#{@project_id}", @doc_id, (error, result) =>
+					rclient_history.sismember HistoryKeys.docsWithHistoryOps({@project_id}), @doc_id, (error, result) =>
 						result.should.equal 1
 						done()
 			


### PR DESCRIPTION
for consistency the acceptance tests could be updated to use Settings.redis.history instead of Settings.redis.web for the redis operations related to track changes