### PR TITLE
put a limit on the number of ops per iteration

### DIFF
--- a/app/coffee/RealTimeRedisManager.coffee
+++ b/app/coffee/RealTimeRedisManager.coffee
@@ -3,11 +3,13 @@ rclient = require("redis-sharelatex").createClient(Settings.redis.realtime)
 Keys = Settings.redis.realtime.key_schema
 logger = require('logger-sharelatex')
 
+MAX_OPS_PER_ITERATION = 8 # process a limited number of ops for safety
+
 module.exports = RealTimeRedisManager =
 	getPendingUpdatesForDoc : (doc_id, callback)->
 		multi = rclient.multi()
-		multi.lrange Keys.pendingUpdates({doc_id}), 0 , -1
-		multi.del Keys.pendingUpdates({doc_id})
+		multi.lrange Keys.pendingUpdates({doc_id}), 0, (MAX_OPS_PER_ITERATION-1)
+		multi.ltrim Keys.pendingUpdates({doc_id}), MAX_OPS_PER_ITERATION, -1
 		multi.exec (error, replys) ->
 			return callback(error) if error?
 			jsonUpdates = replys[0]

--- a/app/coffee/UpdateManager.coffee
+++ b/app/coffee/UpdateManager.coffee
@@ -40,6 +40,7 @@ module.exports = UpdateManager =
 	fetchAndApplyUpdates: (project_id, doc_id, callback = (error) ->) ->
 		RealTimeRedisManager.getPendingUpdatesForDoc doc_id, (error, updates) =>
 			return callback(error) if error?
+			logger.log {project_id: project_id, doc_id: doc_id, count: updates.length}, "processing updates"
 			if updates.length == 0
 				return callback()
 			async.eachSeries updates,

--- a/test/unit/coffee/RealTimeRedisManager/RealTimeRedisManagerTests.coffee
+++ b/test/unit/coffee/RealTimeRedisManager/RealTimeRedisManagerTests.coffee
@@ -26,7 +26,7 @@ describe "RealTimeRedisManager", ->
 	describe "getPendingUpdatesForDoc", ->
 		beforeEach ->
 			@rclient.lrange = sinon.stub()
-			@rclient.del = sinon.stub()
+			@rclient.ltrim = sinon.stub()
 
 		describe "successfully", ->
 			beforeEach ->
@@ -40,12 +40,12 @@ describe "RealTimeRedisManager", ->
 			
 			it "should get the pending updates", ->
 				@rclient.lrange
-					.calledWith("PendingUpdates:#{@doc_id}", 0, -1)
+					.calledWith("PendingUpdates:#{@doc_id}", 0, 7)
 					.should.equal true
 
 			it "should delete the pending updates", ->
-				@rclient.del
-					.calledWith("PendingUpdates:#{@doc_id}")
+				@rclient.ltrim
+					.calledWith("PendingUpdates:#{@doc_id}", 8, -1)
 					.should.equal true
 
 			it "should call the callback with the updates", ->


### PR DESCRIPTION
if we get into a situation where there are a large number of ops queued up, avoid trying to process all of them at once, which could cause the lock to time out.

this could happen If we somehow get a backlog of ops.  I've chosen 8 as a small finite number that would be reasonable to process in 30 seconds (maybe we should make it smaller - perhaps only 1?)

have added logging so we can get some stats on how many ops we typically process in each iteration.