### PR TITLE
fail safely if doc cannot be loaded

### DIFF
--- a/app/coffee/DocumentManager.coffee
+++ b/app/coffee/DocumentManager.coffee
@@ -28,6 +28,13 @@ module.exports = DocumentManager =
 			else
 				callback null, lines, version, ranges, true
 
+	ensureDocIsLoaded: (project_id, doc_id, callback = (error) ->) ->
+		RedisManager.checkDocInMemory project_id, doc_id, (error) ->
+			if error?
+				DocumentManager.getDoc project_id, doc_id, callback
+			else
+				callback()
+
 	getDocAndRecentOps: (project_id, doc_id, fromVersion, _callback = (error, lines, version, recentOps, ranges) ->) ->
 		timer = new Metrics.Timer("docManager.getDocAndRecentOps")
 		callback = (args...) ->

--- a/app/coffee/RedisManager.coffee
+++ b/app/coffee/RedisManager.coffee
@@ -30,6 +30,12 @@ historyKeys = Settings.redis.history.key_schema
 module.exports = RedisManager =
 	rclient: rclient
 
+	checkDocInMemory: (project_id, doc_id, callback) ->
+		rclient.exists keys.docLines(doc_id:doc_id), (error, result) ->
+			return callback(error) if error?
+			return callback new Error("doc not in memory") if result isnt 1
+			callback()
+
 	putDocInMemory : (project_id, doc_id, docLines, version, ranges, _callback)->
 		timer = new metrics.Timer("redis.put-doc")
 		callback = (error) ->

--- a/app/coffee/UpdateManager.coffee
+++ b/app/coffee/UpdateManager.coffee
@@ -14,10 +14,14 @@ RangesManager = require "./RangesManager"
 module.exports = UpdateManager =
 	processOutstandingUpdates: (project_id, doc_id, callback = (error) ->) ->
 		timer = new Metrics.Timer("updateManager.processOutstandingUpdates")
-		UpdateManager.fetchAndApplyUpdates project_id, doc_id, (error) ->
-			timer.done()
+		DocumentManager.ensureDocIsLoaded project_id, doc_id, (error) ->
+			# an error at this point is safe, because we haven't consumed any ops yet
 			return callback(error) if error?
-			callback()
+			UpdateManager.fetchAndApplyUpdates project_id, doc_id, (error) ->
+				timer.done()
+				# now we have taken ops off the queue so errors here will cause data loss
+				return callback(error) if error?
+				callback()
 
 	processOutstandingUpdatesWithLock: (project_id, doc_id, callback = (error) ->) ->
 		LockManager.tryLock doc_id, (error, gotLock, lockValue) =>

--- a/test/unit/coffee/UpdateManager/UpdateManagerTests.coffee
+++ b/test/unit/coffee/UpdateManager/UpdateManagerTests.coffee
@@ -25,6 +25,7 @@ describe "UpdateManager", ->
 
 	describe "processOutstandingUpdates", ->
 		beforeEach ->
+			@DocumentManager.ensureDocIsLoaded = sinon.stub().callsArg(2)
 			@UpdateManager.fetchAndApplyUpdates = sinon.stub().callsArg(2)
 			@UpdateManager.processOutstandingUpdates @project_id, @doc_id, @callback
 
@@ -42,6 +43,7 @@ describe "UpdateManager", ->
 			beforeEach ->
 				@LockManager.tryLock = sinon.stub().callsArgWith(1, null, true, @lockValue = "mock-lock-value")
 				@LockManager.releaseLock = sinon.stub().callsArg(2)
+				@RedisManager.checkDocInMemory = sinon.stub().callsArg(2)
 				@UpdateManager.continueProcessingUpdatesWithLock = sinon.stub().callsArg(2)
 				@UpdateManager.processOutstandingUpdates = sinon.stub().callsArg(2)
 
@@ -90,7 +92,8 @@ describe "UpdateManager", ->
 
 			it "should not process the updates", ->
 				@UpdateManager.processOutstandingUpdates.called.should.equal false
-				
+
+
 	describe "continueProcessingUpdatesWithLock", ->
 		describe "when there are outstanding updates", ->
 			beforeEach ->


### PR DESCRIPTION
change the order of processing so that after taking the lock, the first thing we do is load the document - before any ops are deleted from the queue.

if the request to load the doc fails, we can release the lock and fail gracefully without losing any ops

previously a timeout on the web request would cause ops to be discarded, because it would happen inside applyUpdate.


