### PR TITLE
add metric for active workers

### DIFF
--- a/app/coffee/DispatchManager.coffee
+++ b/app/coffee/DispatchManager.coffee
@@ -20,7 +20,9 @@ module.exports = DispatchManager =
 					[list_name, doc_key] = result
 					[project_id, doc_id] = Keys.splitProjectIdAndDocId(doc_key)
 					# Dispatch this in the background
+					Metrics.gauge "processingUpdates", "+1"  # increments/decrements gauge with +/- sign
 					UpdateManager.processOutstandingUpdatesWithLock project_id, doc_id, (error) ->
+						Metrics.gauge "processingUpdates", "-1"
 						logger.error err: error, project_id: project_id, doc_id: doc_id, "error processing update" if error?
 					callback()
 						


### PR DESCRIPTION
add metric for the number of active processOutstandingUpdatesWithLock calls in progress at any given time.  When we have timeout errors we could be getting a backlog of calls which makes everything worse.