### PR TITLE
limit worker calls

### DIFF
--- a/app/coffee/RateLimitManager.coffee
+++ b/app/coffee/RateLimitManager.coffee
@@ -1,0 +1,36 @@
+Settings = require('settings-sharelatex')
+logger = require('logger-sharelatex')
+Metrics = require('./Metrics')
+
+module.exports = class RateLimiter
+
+	constructor: (number = 10) ->
+		@ActiveWorkerCount = 0
+		@CurrentWorkerLimit = number
+		@BaseWorkerCount = number
+
+	_adjustLimitUp: () ->
+		@CurrentWorkerLimit += 0.1 # allow target worker limit to increase gradually
+
+	_adjustLimitDown: () ->
+		@CurrentWorkerLimit = Math.max @BaseWorkerCount, (@CurrentWorkerLimit * 0.9)
+		logger.log {currentLimit: Math.ceil(@CurrentWorkerLimit)}, "reducing rate limit"
+
+	_trackAndRun: (task, callback = () ->) ->
+		@ActiveWorkerCount++
+		Metrics.gauge "processingUpdates", "+1"  # increments/decrements gauge with +/- sign
+		task (err) =>
+			@ActiveWorkerCount--
+			Metrics.gauge "processingUpdates", "-1"
+			callback(err)
+
+	run: (task, callback) ->
+		if @ActiveWorkerCount < @CurrentWorkerLimit
+			@_trackAndRun task  # below the limit, just put the task in the background
+			callback()         # return immediately
+			if @CurrentWorkerLimit > @BaseWorkerCount
+				@_adjustLimitDown()
+		else
+			logger.log {active: @ActiveWorkerCount, currentLimit: Math.ceil(@CurrentWorkerLimit)}, "hit rate limit"
+			@_trackAndRun task, callback # only return after task completes
+			@_adjustLimitUp()

--- a/test/unit/coffee/DispatchManager/DispatchManagerTests.coffee
+++ b/test/unit/coffee/DispatchManager/DispatchManagerTests.coffee
@@ -14,6 +14,7 @@ describe "DispatchManager", ->
 					realtime: {}
 			"redis-sharelatex": @redis = {}
 		@callback = sinon.stub()
+		@RateLimiter = { run: (task,cb) -> task(cb) } # run task without rate limit
 
 	describe "each worker", ->
 		beforeEach ->
@@ -21,7 +22,7 @@ describe "DispatchManager", ->
 				auth: sinon.stub()
 			@redis.createClient = sinon.stub().returns @client
 			
-			@worker = @DispatchManager.createDispatcher()
+			@worker = @DispatchManager.createDispatcher(@RateLimiter)
 			
 		it "should create a new redis client", ->
 			@redis.createClient.called.should.equal true

--- a/test/unit/coffee/RateLimitManager/RateLimitManager.coffee
+++ b/test/unit/coffee/RateLimitManager/RateLimitManager.coffee
@@ -1,0 +1,90 @@
+sinon = require('sinon')
+chai = require('chai')
+should = chai.should()
+expect = chai.expect
+modulePath = "../../../../app/js/RateLimitManager.js"
+SandboxedModule = require('sandboxed-module')
+
+describe "RateLimitManager", ->
+	beforeEach ->
+		@RateLimitManager = SandboxedModule.require modulePath, requires:
+			"logger-sharelatex": @logger = { log: sinon.stub() }
+			"settings-sharelatex": @settings =
+				redis:
+					realtime: {}
+			"./Metrics": @Metrics =
+				Timer: class Timer
+					done: sinon.stub()
+				gauge: sinon.stub()
+		@callback = sinon.stub()
+		@RateLimiter = new @RateLimitManager(1)
+
+	describe "for a single task", ->
+		beforeEach ->
+			@task = sinon.stub()
+			@RateLimiter.run @task, @callback
+
+		it "should execute the task in the background", ->
+			@task.called.should.equal true
+
+		it "should call the callback", ->
+			@callback.called.should.equal true
+
+		it "should finish with a worker count of one", ->
+			# because it's in the background
+			expect(@RateLimiter.ActiveWorkerCount).to.equal 1
+
+	describe "for multiple tasks", ->
+		beforeEach (done) ->
+			@task = sinon.stub()
+			@finalTask = sinon.stub()
+			task = (cb) =>
+				@task()
+				setTimeout cb, 100
+			finalTask = (cb) =>
+				@finalTask()
+				setTimeout cb, 100
+			@RateLimiter.run task, @callback
+			@RateLimiter.run task, @callback
+			@RateLimiter.run task, @callback
+			@RateLimiter.run finalTask, (err) =>
+				@callback(err)
+				done()
+
+		it "should execute the first three tasks", ->
+			@task.calledThrice.should.equal true
+
+		it "should execute the final task", ->
+			@finalTask.called.should.equal true
+
+		it "should call the callback", ->
+			@callback.called.should.equal true
+
+		it "should finish with worker count of zero", ->
+			expect(@RateLimiter.ActiveWorkerCount).to.equal 0
+
+	describe "for a mixture of long-running tasks", ->
+		beforeEach (done) ->
+			@task = sinon.stub()
+			@finalTask = sinon.stub()
+			finalTask = (cb) =>
+				@finalTask()
+				setTimeout cb, 100
+			@RateLimiter.run @task, @callback
+			@RateLimiter.run @task, @callback
+			@RateLimiter.run @task, @callback
+			@RateLimiter.run finalTask, (err) =>
+				@callback(err)
+				done()
+
+		it "should execute the first three tasks", ->
+			@task.calledThrice.should.equal true
+
+		it "should execute the final task", ->
+			@finalTask.called.should.equal true
+
+		it "should call the callback", ->
+			@callback.called.should.equal true
+
+		it "should finish with worker count of three", ->
+			expect(@RateLimiter.ActiveWorkerCount).to.equal 3


### PR DESCRIPTION
use an adaptive rate limit to smooth out the worker calls if there is a sudden spike in updates coming from redis

if we go over the threshold we wait for the background processes to finish before starting new ones

we increase the threshold gradually (by 1 for every 10 updates processed)